### PR TITLE
Prevent server crash when adding looted schematics where target iff c…

### DIFF
--- a/MMOCoreORB/src/server/zone/objects/draftschematic/DraftSchematicImplementation.cpp
+++ b/MMOCoreORB/src/server/zone/objects/draftschematic/DraftSchematicImplementation.cpp
@@ -72,6 +72,15 @@ void DraftSchematicImplementation::insertIngredients(ObjectControllerMessage* ms
 void DraftSchematicImplementation::sendResourceWeightsTo(CreatureObject* player) {
 
 	Vector<Reference<ResourceWeight* > >* resourceWeights = schematicTemplate->getResourceWeights();
+	
+	if (resourceWeights == NULL){
+		Logger::console.error("resourceWeights null for draft schematic template: " + schematicTemplate->getTemplateFileName() + " This is likely due to a typo in the lua template file.");		
+		player->sendSystemMessage("There was an error on server that prevented this crafting action from completing. The error has been logged. Please contact support for further assistance.");
+		
+		// Note: The broken draft schematic will be added to the player's crafting tool, but the tool will not let them use it.
+
+		return;
+	}
 
 	ObjectControllerMessage* msg = new ObjectControllerMessage(player->getObjectID(), 0x0B, 0x0207);
 


### PR DESCRIPTION
…annot be found

Note: The broken draft schematic will be added to the player's crafting tool, but the tool will not let them use it and the server will not crash.